### PR TITLE
Misc

### DIFF
--- a/prolog/clpBNR.pl
+++ b/prolog/clpBNR.pl
@@ -95,6 +95,7 @@ integer                               %% must be an integer value
 % debug feature control and messaging
 :- if(exists_source(swish(lib/swish_debug))).
 :- use_module(swish(lib/swish_debug)).
+:- set_prolog_flag(clpBNR_swish, true).
 :- else.
 :- use_module(library(debug)).
 :- endif.
@@ -686,12 +687,11 @@ chk_primitive_(Prim) :-  % wraps safe usage of unsafe current_predicate/2
 
 sandbox:safe_primitive(clpBNR:chk_primitive_(_Prim)).
 
+:- if(\+current_prolog_flag(clpBNR_swish, true)).
 % to invoke user defined primitive
 call_user_primitive(Prim, P, InArgs, OutArgs) :-  % wraps unsafe meta call/N
 	call(clpBNR:Prim, '$op', InArgs, OutArgs, P).
-
-% really unsafe, but in a pengine a user can't define any predicates in another module, so this is safe
-sandbox:safe_meta(clpBNR:call_user_primitive(_Prim, _P, _InArgs, _OutArgs), []).
+:- endif.
 
 % only called when argument is ground
 safe_(E) :- atomic(E), !.  % all atomics, including [] - allows possibility of user defined arithmetic types

--- a/prolog/clpBNR.pl
+++ b/prolog/clpBNR.pl
@@ -108,6 +108,7 @@ integer                               %% must be an integer value
 :- else.
 :- use_module(library(debug)).
 :- endif.
+:- use_module(library(arithmetic), []).
 
 version("0.11.4").
 
@@ -347,7 +348,7 @@ interval_domain_(T,(L,H),Dom) :- Dom=..[T,L,H].
 %
 %  delta(Int, Wid) width/span of an interval or numeric value, can be infinite
 %
-:- arithmetic_function(user:(delta/1)).
+:- arithmetic_function(delta/1).
 
 delta(Int, Wid) :-
 	getValue(Int,(L,H)),
@@ -361,7 +362,7 @@ delta(Int, Wid) :-
 %	40 (2), 10.1145/2493882. hal-00576641v1
 % Exception, single infinite bound treated as largest finite FP value
 %
-:- arithmetic_function(user:(midpoint/1)).
+:- arithmetic_function(midpoint/1).
 
 midpoint(Int, Mid) :-
 	getValue(Int,(L,H)),
@@ -377,7 +378,7 @@ midpoint_(L,H,M)       :- M1 is L/2 + H/2, M=M1.        % general case
 % Med = 0 if Int contains 0, else a number which divides Int into equal
 % numbers of FP values. Med is always a float
 %
-:- arithmetic_function(user:(median/1)).
+:- arithmetic_function(median/1).
 
 median(Int, Med) :-
 	getValue(Int,(L,H)),

--- a/prolog/clpBNR.pl
+++ b/prolog/clpBNR.pl
@@ -168,8 +168,10 @@ user:exception(undefined_global_variable,'clpBNR:thread_init_done',retry) :- !,
 :- create_prolog_flag(clpBNR_default_precision,6,[type(integer),keep(true)]).
 :- create_prolog_flag(clpBNR_verbose,false,[type(boolean),keep(true)]).
 
-sandbox:safe_prolog_flag(Flag,_) :- 
-	memberchk(Flag,[clpBNR_iteration_limit,clpBNR_default_precision,clpBNR_verbose]).
+sandbox:safe_prolog_flag(clpBNR_iteration_limit,_).
+sandbox:safe_prolog_flag(clpBNR_default_precision,_).
+sandbox:safe_prolog_flag(clpBNR_verbose,_).
+
 %
 % Set public flags (see module/thread initialization)
 %

--- a/prolog/clpBNR.pl
+++ b/prolog/clpBNR.pl
@@ -24,15 +24,6 @@
  *	SOFTWARE.
  */
 
-:- if((current_prolog_flag(version,V), V < 90105)).
-
-% Use history(expanded(...) from boot/messages.pl to avoid additional message template
-:- print_message(error,history(expanded("This version of clpBNR requires SWIP 9.1.5 or greater"))).
-
-:- op(1199, xfx, ::).         % suppresses errors while parsing
-
-:- else.
-
 :- module(clpBNR,          % SWI module declaration
 	[
 	op(700, xfx, ::),
@@ -108,6 +99,11 @@ integer                               %% must be an integer value
 :- use_module(library(debug)).
 :- endif.
 :- use_module(library(arithmetic)).
+:- use_module(library(prolog_versions)).
+
+:- require_prolog_version('9.1.21-15', % Import/Export of arithmetic functions
+			  [ rational   % Demand rational number support
+			  ]).
 
 version("0.11.4").
 
@@ -1075,8 +1071,3 @@ init_clpBNR :-  % Note, most initialization deferred to "first use" - see user:e
 	check_features.
 
 :- initialization(init_clpBNR, now).
-
-:- endif.
-
-% remove possible temporary op definition
-:- (current_op(1199,A,::) -> op(0,A,::) ; true).

--- a/prolog/clpBNR.pl
+++ b/prolog/clpBNR.pl
@@ -541,7 +541,7 @@ attr_unify_hook(interval(Type1,V1,Nodelist1,Flags1), Int) :-   % unifying two in
 
 attr_unify_hook(interval(Type,Val,_Nodelist,_Flags), V) :-   % new value out of range
 	g_inc('clpBNR:evalNodeFail'),  % count of primitive call failures
-	debugging(clpBNR, true),       % fail immediately unless debug=true
+	debugging(clpBNR),	       % fail immediately unless debug=true
 	debug_clpBNR_('Failed to unify ~w::(~w) with ~w',[Type,Val,V]),
 	fail.
 

--- a/prolog/clpBNR.pl
+++ b/prolog/clpBNR.pl
@@ -111,8 +111,6 @@ integer                               %% must be an integer value
 
 version("0.11.4").
 
-:- style_check(-discontiguous).
-
 %
 % Define debug_clpBNR_/2 before turning on optimizer removing debug calls.
 % Note: global "optimise" flag will be restored after load completes.

--- a/prolog/clpBNR/ia_primitives.pl
+++ b/prolog/clpBNR/ia_primitives.pl
@@ -882,5 +882,7 @@ imB_rel_(Z,X,Y,     NewZ,NewX,NewY, _P) :- ^(Z,(0,1),NewZ), ^(X,(0,1),NewX), ^(Y
 
 % User defined IA primitives
 
+:- if(\+current_prolog_flag(clpBNR_swish, true)).
 narrowing_op(user(Prim), P, InArgs, OutArgs) :-
 	call_user_primitive(Prim, P, InArgs, OutArgs).  % from main module body
+:- endif.


### PR DESCRIPTION
I did some reading through the latest version.    Made a pull request with mostly minor issues.    Running this version requires the git version of Prolog, so you may not want to merge this to the public master before the last release.    The change that blocks this is a improvement to library(arithmetic) to allow for import/export of user defined functions.    Your definition was rather dubious, defining the function in `user`, while the exported implementation may not get into `user`.

I removed the singleton style check and the singletons (the builtin editor makes this quick).   Two singletons remain.  See warnings.   I think both are bugs (possibly not affecting global functioning of the library).

Please have a look.   If you agree with this, I'm happy to add clpBNR to the public SWISH image.