### PR TITLE
Added index.json to avoid examples in the main menu

### DIFF
--- a/swish/index.json
+++ b/swish/index.json
@@ -1,0 +1,6 @@
+{ "comment": "The files in this directory are not in the Examples menu,
+              but included from the Prolog tutorials page",
+
+  "menu": [],
+  "files": []
+}


### PR DESCRIPTION
The clpBRN example now ended up in the main examples menu.    I added index.json to avoid that.