### PR TITLE
FIXED: Avoid instantiation of attributed variables in term_html:portray//2

### DIFF
--- a/prolog/clpBNR/ia_utilities.pl
+++ b/prolog/clpBNR/ia_utilities.pl
@@ -116,8 +116,11 @@ add_names_([Name = Var|Bindings],Verbose,IntFlag) :-
 % portray (HTML)
 :- multifile(term_html:portray//2).
 
-term_html:portray('$clpBNR...'(Out),_) -->   % avoid quotes on stringified number in ellipsis format
-	{ string(Out) },
+term_html:portray(Term,_) -->   % avoid quotes on stringified number in ellipsis format
+	{ nonvar(Term),
+	  Term = '$clpBNR...'(Out),
+	  string(Out)
+	},
 	html(span(class('pl-float'), [Out, '...'])).
 
 % for answer formatting


### PR DESCRIPTION
term_html:portray//2 is also called for attvars.   We must avoid trying to bind these.